### PR TITLE
Add simple install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(openssl-cmake)
 
+include(GNUInstallDirs)
+
 if (POLICY CMP0135)
     # policy CMP0135 will use OLD behavior for consistency
     cmake_policy(SET CMP0135 OLD)
@@ -55,7 +57,7 @@ if (SYSTEM_OPENSSL)
     add_custom_target(openssl)
 else()
     # build our own or use prebuilts
-    
+
     # set up fake targets
     add_library(ssl_lib STATIC IMPORTED GLOBAL)
     add_library(crypto_lib STATIC IMPORTED GLOBAL)
@@ -72,14 +74,14 @@ else()
 
     set(OPENSSL_LIBSSL_PATH ${OPENSSL_PREFIX}/usr/local/lib/libssl.a)
     set(OPENSSL_LIBCRYPTO_PATH ${OPENSSL_PREFIX}/usr/local/lib/libcrypto.a)
-    
+
     # set up openssl target
     if (BUILD_OPENSSL)
         include(BuildOpenSSL)
     else()
         include(PrebuiltOpenSSL)
     endif()
-    
+
     # set import locations
     set_target_properties(ssl_lib PROPERTIES IMPORTED_LOCATION ${OPENSSL_LIBSSL_PATH})
     set_target_properties(crypto_lib PROPERTIES IMPORTED_LOCATION ${OPENSSL_LIBCRYPTO_PATH})
@@ -91,4 +93,9 @@ else()
     # add fake targets to common target
     add_dependencies(ssl_lib openssl)
     add_dependencies(crypto_lib openssl)
+
+    install(DIRECTORY ${OPENSSL_PREFIX}/usr/local/include/
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(DIRECTORY ${OPENSSL_PREFIX}/usr/local/lib/
+            DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()


### PR DESCRIPTION
This adds very simple install support for `libssl` and `libcrypto` so other libraries or executables can find them.

Below is an example of using this install support to have `libcurl` depend on the output of `openssl-cmake` and then link against OpenSSL.

```cmake
cmake_minimum_required(VERSION 3.22)

project(third-party)

include(ExternalProject)

ExternalProject_Add(
  openssl-cmake
  GIT_REPOSITORY https://github.com/pr0g/openssl-cmake.git
  GIT_TAG f6119443c903c68e6bb16012c6e60d90c68b5d0e
  PREFIX ${CMAKE_CURRENT_BINARY_DIR}
  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl/build/Debug
  INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
  CMAKE_ARGS -DBUILD_OPENSSL=ON -DOPENSSL_BUILD_VERSION=3.1.2
             -DSYSTEM_OPENSSL=OFF -DOPENSSL_MODULES=""
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
  CMAKE_CACHE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=d)

ExternalProject_Add(
  curl
  GIT_REPOSITORY https://github.com/curl/curl.git
  GIT_TAG curl-8_2_1
  DEPENDS openssl-cmake
  PREFIX ${CMAKE_CURRENT_BINARY_DIR}
  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/curl/build/Debug
  INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -DOPENSSL_ROOT_DIR=<INSTALL_DIR>
  CMAKE_CACHE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=d)

# see explanation below
add_custom_command(
  TARGET curl
  POST_BUILD
  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/rpath-fixup.sh
  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
  COMMENT "Fixing-up rpaths...")
```

The custom command is in relation to https://github.com/viaduck/openssl-cmake/issues/14 for more context, it essentially looks like this....

```
# rpath-fixup.sh
#!/bin/bash

install_name_tool -id "@rpath/libssl.3.dylib" build/lib/libssl.3.dylib
install_name_tool -change "/usr/local/lib/libcrypto.3.dylib" "@rpath/libcrypto.3.dylib" build/lib/libssl.3.dylib
install_name_tool -id "@rpath/libcrypto.3.dylib" build/lib/libcrypto.3.dylib
install_name_tool -change "/usr/local/lib/libssl.3.dylib" "@rpath/libssl.3.dylib" build/lib/libcurl.4.8.0.dylib
install_name_tool -change "/usr/local/lib/libcrypto.3.dylib" "@rpath/libcrypto.3.dylib" build/lib/libcurl.4.8.0.dylib
```