### PR TITLE
Restrict install step to OpenSSL subbuild

### DIFF
--- a/cmake/BuildOpenSSL.cmake
+++ b/cmake/BuildOpenSSL.cmake
@@ -193,7 +193,7 @@ else()
 
         INSTALL_COMMAND ${BUILD_ENV_TOOL} <SOURCE_DIR> -- ${PERL_PATH_FIX_INSTALL}
         COMMAND ${BUILD_ENV_TOOL} <SOURCE_DIR> -- ${MAKE_PROGRAM} DESTDIR=${OPENSSL_PREFIX} install_sw ${INSTALL_OPENSSL_MAN}
-        COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} ${CMAKE_BINARY_DIR}                    # force CMake-reload
+        COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} "${CMAKE_BINARY_DIR}/_deps/openssl-subbuild"                    # force CMake-reload
 
         LOG_INSTALL 1
     )


### PR DESCRIPTION
Instead of running install in the top-level build directory (`CMAKE_BINARY_DIR`), which would install all other modules, too.

This is a problem in builds that have modules that do not need to be installed (and just provide archives for a build).
